### PR TITLE
Fix race condition in tests

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -22,9 +22,9 @@ jobs:
         uses: actions/checkout@v3
       - uses: jpribyl/action-docker-layer-caching@v0.1.1
         with:
-          key: ${{ matrix.shmem }}-2-{hash}
+          key: ${{ matrix.shmem }}-3-{hash}
           restore-keys: |
-            ${{ matrix.shmem }}-2-
+            ${{ matrix.shmem }}-3-
       - name: Build Docker container
         run: docker build -t local docker/${{ matrix.shmem }}/
       - name: run shmem4py test-1

--- a/test/test_buf.py
+++ b/test/test_buf.py
@@ -11,7 +11,7 @@ class TestBuf(unittest.TestCase):
         self.assertTrue(isinstance(cdata, shmem.ffi.CData))
         self.assertEqual(csize, 4)
         self.assertEqual(ctype, 'double')
-        
+
     def testReadOnly(self):
         a = np.zeros(1)
         a.flags.writeable = False

--- a/test/test_ptr.py
+++ b/test/test_ptr.py
@@ -34,6 +34,8 @@ class TestPtr(unittest.TestCase):
                 shmem.barrier_all()
                 self.assertEqual(sym[0], mype)
 
+            shmem.barrier_all()
+
             ploc = shmem.ptr(sym, pvpe)
             if ploc is not None:
                 self.assertTrue(isinstance(ploc, np.ndarray))
@@ -65,6 +67,9 @@ class TestPtr(unittest.TestCase):
                         loc[...] = nxpe
                         shmem.barrier_all()
                         self.assertTrue(np.all(sym == mype))
+
+                    shmem.barrier_all()
+
                     loc = shmem.ptr(sym, pvpe)
                     if loc is not None:
                         self.assertTrue(isinstance(loc, np.ndarray))

--- a/test/test_ptr.py
+++ b/test/test_ptr.py
@@ -23,7 +23,7 @@ class TestPtr(unittest.TestCase):
         for t in types:
             sym = shmem.new_array(1, t)
             sym[0] = npes
-            shmem.barrier_all()
+            shmem.sync_all()
 
             nloc = shmem.ptr(sym, nxpe)
             if nloc is not None:
@@ -31,7 +31,7 @@ class TestPtr(unittest.TestCase):
                 self.assertEqual(nloc.dtype, sym.dtype)
                 self.assertEqual(nloc[0], npes)
                 nloc[0] = nxpe
-                shmem.barrier_all()
+                shmem.sync_all()
                 self.assertEqual(sym[0], mype)
 
             shmem.sync_all()
@@ -42,7 +42,7 @@ class TestPtr(unittest.TestCase):
                 self.assertEqual(ploc.dtype, sym.dtype)
                 self.assertEqual(ploc[0], pvpe)
                 ploc[0] = mype
-                shmem.barrier_all()
+                shmem.sync_all()
                 self.assertEqual(sym[0], nxpe)
 
             shmem.free(sym)
@@ -56,7 +56,7 @@ class TestPtr(unittest.TestCase):
             for d in (0, 1, 2, 3):
                 for order in ('C', 'F'):
                     sym = shmem.full((3,)*d, npes, dtype=t, order=order)
-                    shmem.barrier_all()
+
                     loc = shmem.ptr(sym, nxpe)
                     if loc is not None:
                         self.assertTrue(isinstance(loc, np.ndarray))
@@ -65,7 +65,7 @@ class TestPtr(unittest.TestCase):
                         self.assertEqual(loc.strides, sym.strides)
                         self.assertTrue(np.all(loc == npes))
                         loc[...] = nxpe
-                        shmem.barrier_all()
+                        shmem.sync_all()
                         self.assertTrue(np.all(sym == mype))
 
                     shmem.sync_all()
@@ -78,8 +78,9 @@ class TestPtr(unittest.TestCase):
                         self.assertEqual(loc.strides, sym.strides)
                         self.assertTrue(np.all(loc == pvpe))
                         loc[...] = mype
-                        shmem.barrier_all()
+                        shmem.sync_all()
                         self.assertTrue(np.all(sym == nxpe))
+
                     shmem.free(sym)
 
 

--- a/test/test_ptr.py
+++ b/test/test_ptr.py
@@ -34,7 +34,7 @@ class TestPtr(unittest.TestCase):
                 shmem.barrier_all()
                 self.assertEqual(sym[0], mype)
 
-            shmem.barrier_all()
+            shmem.sync_all()
 
             ploc = shmem.ptr(sym, pvpe)
             if ploc is not None:
@@ -68,7 +68,7 @@ class TestPtr(unittest.TestCase):
                         shmem.barrier_all()
                         self.assertTrue(np.all(sym == mype))
 
-                    shmem.barrier_all()
+                    shmem.sync_all()
 
                     loc = shmem.ptr(sym, pvpe)
                     if loc is not None:

--- a/test/test_query.py
+++ b/test/test_query.py
@@ -15,17 +15,17 @@ class TestQuery(unittest.TestCase):
             )
         )
 
-    def testPEAccesible(self):
+    def testPEAccessible(self):
         flag = shmem.pe_accessible(shmem.my_pe())
         self.assertTrue(flag)
 
-    def testAddrAccesibleCData(self):
+    def testAddrAccessibleCData(self):
         addr = shmem.new_array(1, 'i')
         flag = shmem.addr_accessible(addr, shmem.my_pe())
         shmem.free(addr)
         self.assertTrue(flag)
 
-    def testAddrAccesibleNumPy(self):
+    def testAddrAccessibleNumPy(self):
         addr = shmem.empty(1, dtype='i')
         flag = shmem.addr_accessible(addr, shmem.my_pe())
         shmem.free(addr)


### PR DESCRIPTION
I think without the barrier, PE 1 can modify ``sym`` after completing the barrier in line 34 but before PE 0 calls the assert. Does it make sense?