### PR TITLE
Test PSM3_DEVICES="self,shm"

### DIFF
--- a/docker/oshmpi_fedora/Dockerfile
+++ b/docker/oshmpi_fedora/Dockerfile
@@ -18,3 +18,4 @@ RUN cd $INSTALL_DIR                                                             
 ENV PATH="/home/shmem/oshmpi/install/bin/:/usr/lib64/mpich/bin/:${PATH}"
 RUN ln -s /usr/bin/python3 /usr/bin/python
 RUN python -m pip install numpy cffi
+ENV PSM3_DEVICES="self,shm"


### PR DESCRIPTION
`oshmpi_fedora` container stopped working with `mpich-4.1.2-3.fc39.x86_64`, `libpsm2-11.2.230-2.fc39.x86_64`, `libfabric-1.18.1-3.fc39.x86_64`:

```
28463ef361be:rank0: PSM3 can't open nic unit: 0 (err=23)
Abort(673306767): Fatal error in internal_Init_thread: Other MPI error, error stack:
internal_Init_thread(67).: MPI_Init_thread(argc=(nil), argv=(nil), required=0, provided=0x7ffcc61dcfac) failed
MPII_Init_thread(234)....: 
MPID_Init(513)...........: 
MPIDI_OFI_init_local(604): 
create_vni_context(982)..: OFI endpoint open failed (ofi_init.c:982:create_vni_context:Cannot allocate memory)
28463ef361be:rank0.python: Failed to get eth0 (unit 0) cpu set
make: *** [makefile:19: test-1] Error 143
```

As in https://github.com/easybuilders/easybuild-easyconfigs/issues/18925, using `PSM3_DEVICES='self,shm'` fixed the issue.