### PR TITLE
SOS: Clone tests-sos submodule

### DIFF
--- a/docker/sos_fedora/Dockerfile
+++ b/docker/sos_fedora/Dockerfile
@@ -23,7 +23,7 @@ RUN cd $INSTALL_DIR                                                       && \
 
 # Build SOS
 RUN cd $INSTALL_DIR                                                                         && \
-    git clone https://github.com/Sandia-OpenSHMEM/SOS.git                                   && \
+    git clone --recursive https://github.com/Sandia-OpenSHMEM/SOS.git                       && \
     cd SOS                                                                                  && \
     ./autogen.sh                                                                            && \
     # To build SOS w/ basic Libfabric                                                          \

--- a/docker/sos_ubuntu/Dockerfile
+++ b/docker/sos_ubuntu/Dockerfile
@@ -31,7 +31,7 @@ RUN cd $INSTALL_DIR                                                       && \
 
 # Build SOS
 RUN cd $INSTALL_DIR                                                                         && \
-    git clone https://github.com/Sandia-OpenSHMEM/SOS.git                                   && \
+    git clone --recursive https://github.com/Sandia-OpenSHMEM/SOS.git                       && \
     cd SOS                                                                                  && \
     ./autogen.sh                                                                            && \
     # To build SOS w/ basic Libfabric                                                          \


### PR DESCRIPTION
Starting from https://github.com/Sandia-OpenSHMEM/SOS/commit/48cbd790d018205d52a672ac1d9a40c5720903dc, `autogen.sh` requires the `tests-sos` submodule to be cloned.