### PR TITLE
Use venv

### DIFF
--- a/.github/workflows/containers.yml
+++ b/.github/workflows/containers.yml
@@ -25,10 +25,10 @@ jobs:
       - name: Build Docker container
         run: docker build -t local docker/${{ matrix.shmem }}/
       - name: run shmem4py test-1
-        run: docker run -v $PWD:/repo -w/repo local /bin/bash -c "pip install . && make test-1 opt=-v"
+        run: docker run -v $PWD:/repo -w/repo local /bin/bash -c "source /.venv/bin/activate && pip install . && make test-1 opt=-v"
       - name: run shmem4py test-2
-        run: docker run -v $PWD:/repo -w/repo local /bin/bash -c "pip install . && make test-2 opt=-v"
+        run: docker run -v $PWD:/repo -w/repo local /bin/bash -c "source /.venv/bin/activate && pip install . && make test-2 opt=-v"
       - name: run shmem4py demo-test-1
-        run: docker run -v $PWD:/repo -w/repo local /bin/bash -c "pip install . && cd demo && make test-1 opt=-v"
+        run: docker run -v $PWD:/repo -w/repo local /bin/bash -c "source /.venv/bin/activate && pip install . && cd demo && make test-1 opt=-v"
       - name: run shmem4py demo-test-2
-        run: docker run -v $PWD:/repo -w/repo local /bin/bash -c "pip install . && cd demo && make test-2 opt=-v"
+        run: docker run -v $PWD:/repo -w/repo local /bin/bash -c "source /.venv/bin/activate && pip install . && cd demo && make test-2 opt=-v"

--- a/.github/workflows/containers.yml
+++ b/.github/workflows/containers.yml
@@ -25,10 +25,10 @@ jobs:
       - name: Build Docker container
         run: docker build -t local docker/${{ matrix.shmem }}/
       - name: run shmem4py test-1
-        run: docker run -v $PWD:/repo -w/repo local /bin/bash -c "source /.venv/bin/activate && pip install . && make test-1 opt=-v"
+        run: docker run -v $PWD:/repo -w/repo local /bin/bash -c "source /venv/bin/activate && pip install . && make test-1 opt=-v"
       - name: run shmem4py test-2
-        run: docker run -v $PWD:/repo -w/repo local /bin/bash -c "source /.venv/bin/activate && pip install . && make test-2 opt=-v"
+        run: docker run -v $PWD:/repo -w/repo local /bin/bash -c "source /venv/bin/activate && pip install . && make test-2 opt=-v"
       - name: run shmem4py demo-test-1
-        run: docker run -v $PWD:/repo -w/repo local /bin/bash -c "source /.venv/bin/activate && pip install . && cd demo && make test-1 opt=-v"
+        run: docker run -v $PWD:/repo -w/repo local /bin/bash -c "source /venv/bin/activate && pip install . && cd demo && make test-1 opt=-v"
       - name: run shmem4py demo-test-2
-        run: docker run -v $PWD:/repo -w/repo local /bin/bash -c "source /.venv/bin/activate && pip install . && cd demo && make test-2 opt=-v"
+        run: docker run -v $PWD:/repo -w/repo local /bin/bash -c "source /venv/bin/activate && pip install . && cd demo && make test-2 opt=-v"

--- a/docker/oshmem_fedora/Dockerfile
+++ b/docker/oshmem_fedora/Dockerfile
@@ -30,5 +30,4 @@ ENV PATH=/home/shmem/openmpi-4.1.6/install/bin:"${PATH}" \
     OMPI_ALLOW_RUN_AS_ROOT_CONFIRM=1
 
 RUN python3 -m venv .venv
-RUN ln -s /.venv/bin/python /usr/bin/python
-RUN python -m pip install setuptools cffi numpy
+RUN source /.venv/bin/activate &&  pip install setuptools cffi numpy

--- a/docker/oshmem_fedora/Dockerfile
+++ b/docker/oshmem_fedora/Dockerfile
@@ -29,5 +29,6 @@ ENV PATH=/home/shmem/openmpi-4.1.6/install/bin:"${PATH}" \
     OMPI_ALLOW_RUN_AS_ROOT=1 \
     OMPI_ALLOW_RUN_AS_ROOT_CONFIRM=1
 
-RUN ln -s /usr/bin/python3 /usr/bin/python
+RUN python3 -m venv .venv
+RUN ln -s /.venv/bin/python /usr/bin/python
 RUN python -m pip install setuptools cffi numpy

--- a/docker/oshmem_fedora/Dockerfile
+++ b/docker/oshmem_fedora/Dockerfile
@@ -30,5 +30,5 @@ ENV PATH=/home/shmem/openmpi-4.1.6/install/bin:"${PATH}" \
     OMPI_ALLOW_RUN_AS_ROOT=1 \
     OMPI_ALLOW_RUN_AS_ROOT_CONFIRM=1
 
-RUN python3 -m venv .venv
-RUN source /.venv/bin/activate &&  pip install setuptools cffi numpy
+RUN python3 -m venv /venv
+RUN source /venv/bin/activate &&  pip install setuptools cffi numpy

--- a/docker/oshmem_fedora/Dockerfile
+++ b/docker/oshmem_fedora/Dockerfile
@@ -1,4 +1,5 @@
 FROM fedora:latest
+SHELL ["/bin/bash", "-c"]
 
 ENV INSTALL_DIR=/home/shmem
 RUN mkdir /home/shmem

--- a/docker/oshmem_ubuntu/Dockerfile
+++ b/docker/oshmem_ubuntu/Dockerfile
@@ -35,5 +35,5 @@ ENV PATH=/home/shmem/openmpi-4.1.6/install/bin:"${PATH}" \
     OMPI_ALLOW_RUN_AS_ROOT=1 \
     OMPI_ALLOW_RUN_AS_ROOT_CONFIRM=1
 
-RUN python3 -m venv .venv
-RUN source /.venv/bin/activate && pip install numpy cffi
+RUN python3 -m venv /venv
+RUN source /venv/bin/activate && pip install numpy cffi

--- a/docker/oshmem_ubuntu/Dockerfile
+++ b/docker/oshmem_ubuntu/Dockerfile
@@ -10,7 +10,7 @@ RUN apt-get update -y && apt-get install -y \
   automake                                  \
   libtool                                   \
   wget                                      \
-  python3 python3-pip python-is-python3
+  python3 python3-pip python-is-python3 python3-venv
 
 RUN cd $INSTALL_DIR                                                                                                             && \
     wget https://github.com/openucx/ucx/archive/refs/tags/v1.15.0.tar.gz                                                        && \
@@ -33,4 +33,6 @@ ENV PATH=/home/shmem/openmpi-4.1.6/install/bin:"${PATH}" \
     OMPI_ALLOW_RUN_AS_ROOT=1 \
     OMPI_ALLOW_RUN_AS_ROOT_CONFIRM=1
 
+RUN python3 -m venv .venv
+RUN rm /usr/bin/python && ln -s /.venv/bin/python /usr/bin/python
 RUN python -m pip install numpy cffi

--- a/docker/oshmem_ubuntu/Dockerfile
+++ b/docker/oshmem_ubuntu/Dockerfile
@@ -1,4 +1,6 @@
 FROM ubuntu:latest
+SHELL ["/bin/bash", "-c"]
+
 ENV INSTALL_DIR=/home/shmem
 RUN mkdir /home/shmem
 ENV DEBIAN_FRONTEND=noninteractive

--- a/docker/oshmem_ubuntu/Dockerfile
+++ b/docker/oshmem_ubuntu/Dockerfile
@@ -34,5 +34,4 @@ ENV PATH=/home/shmem/openmpi-4.1.6/install/bin:"${PATH}" \
     OMPI_ALLOW_RUN_AS_ROOT_CONFIRM=1
 
 RUN python3 -m venv .venv
-RUN rm /usr/bin/python && ln -s /.venv/bin/python /usr/bin/python
-RUN python -m pip install numpy cffi
+RUN source /.venv/bin/activate && pip install numpy cffi

--- a/docker/oshmpi_fedora/Dockerfile
+++ b/docker/oshmpi_fedora/Dockerfile
@@ -17,6 +17,5 @@ RUN cd $INSTALL_DIR                                                             
 
 ENV PATH="/home/shmem/oshmpi/install/bin/:/usr/lib64/mpich/bin/:${PATH}"
 RUN python3 -m venv .venv
-RUN ln -s /.venv/bin/python /usr/bin/python
-RUN python -m pip install numpy cffi
+RUN source /.venv/bin/activate && pip install numpy cffi
 ENV PSM3_DEVICES="self,shm"

--- a/docker/oshmpi_fedora/Dockerfile
+++ b/docker/oshmpi_fedora/Dockerfile
@@ -16,6 +16,7 @@ RUN cd $INSTALL_DIR                                                             
     make -j && make install
 
 ENV PATH="/home/shmem/oshmpi/install/bin/:/usr/lib64/mpich/bin/:${PATH}"
-RUN ln -s /usr/bin/python3 /usr/bin/python
+RUN python3 -m venv .venv
+RUN ln -s /.venv/bin/python /usr/bin/python
 RUN python -m pip install numpy cffi
 ENV PSM3_DEVICES="self,shm"

--- a/docker/oshmpi_fedora/Dockerfile
+++ b/docker/oshmpi_fedora/Dockerfile
@@ -17,6 +17,6 @@ RUN cd $INSTALL_DIR                                                             
     make -j && make install
 
 ENV PATH="/home/shmem/oshmpi/install/bin/:/usr/lib64/mpich/bin/:${PATH}"
-RUN python3 -m venv .venv
-RUN source /.venv/bin/activate && pip install numpy cffi
+RUN python3 -m venv /venv
+RUN source /venv/bin/activate && pip install numpy cffi
 ENV PSM3_DEVICES="self,shm"

--- a/docker/oshmpi_fedora/Dockerfile
+++ b/docker/oshmpi_fedora/Dockerfile
@@ -1,4 +1,5 @@
 FROM fedora:latest
+SHELL ["/bin/bash", "-c"]
 
 ENV INSTALL_DIR=/home/shmem
 RUN mkdir /home/shmem

--- a/docker/oshmpi_ubuntu/Dockerfile
+++ b/docker/oshmpi_ubuntu/Dockerfile
@@ -23,5 +23,5 @@ RUN cd $INSTALL_DIR                                                             
     make -j && make install
 
 ENV PATH="/home/shmem/oshmpi/install/bin/:${PATH}"
-RUN python3 -m venv .venv
-RUN source /.venv/bin/activate && pip install numpy cffi
+RUN python3 -m venv /venv
+RUN source /venv/bin/activate && pip install numpy cffi

--- a/docker/oshmpi_ubuntu/Dockerfile
+++ b/docker/oshmpi_ubuntu/Dockerfile
@@ -12,7 +12,7 @@ RUN apt-get update -y && apt-get install -y \
   automake                                  \
   libtool                                   \
   mpich                                     \
-  python3 python3-pip python-is-python3
+  python3 python3-pip python-is-python3 python3-venv
 
 RUN cd $INSTALL_DIR                                                                        && \
     git clone https://github.com/pmodels/oshmpi --recurse-submodules                       && \
@@ -22,4 +22,6 @@ RUN cd $INSTALL_DIR                                                             
     make -j && make install
 
 ENV PATH="/home/shmem/oshmpi/install/bin/:${PATH}"
+RUN python3 -m venv .venv
+RUN rm /usr/bin/python && ln -s /.venv/bin/python /usr/bin/python
 RUN python -m pip install numpy cffi

--- a/docker/oshmpi_ubuntu/Dockerfile
+++ b/docker/oshmpi_ubuntu/Dockerfile
@@ -23,5 +23,4 @@ RUN cd $INSTALL_DIR                                                             
 
 ENV PATH="/home/shmem/oshmpi/install/bin/:${PATH}"
 RUN python3 -m venv .venv
-RUN rm /usr/bin/python && ln -s /.venv/bin/python /usr/bin/python
-RUN python -m pip install numpy cffi
+RUN source /.venv/bin/activate && pip install numpy cffi

--- a/docker/oshmpi_ubuntu/Dockerfile
+++ b/docker/oshmpi_ubuntu/Dockerfile
@@ -1,4 +1,5 @@
 FROM ubuntu:latest
+SHELL ["/bin/bash", "-c"]
 
 ENV INSTALL_DIR=/home/shmem
 RUN mkdir /home/shmem

--- a/docker/osss_fedora/Dockerfile
+++ b/docker/osss_fedora/Dockerfile
@@ -37,5 +37,4 @@ ENV PATH=$INSTALL_DIR/osss-ucx/install/bin:/home/shmem/openmpi-4.1.6/install/bin
     OMPI_ALLOW_RUN_AS_ROOT_CONFIRM=1
 
 RUN python3 -m venv .venv
-RUN ln -s /.venv/bin/python /usr/bin/python
-RUN python -m pip install setuptools cffi numpy
+RUN source /.venv/bin/activate && pip install setuptools cffi numpy

--- a/docker/osss_fedora/Dockerfile
+++ b/docker/osss_fedora/Dockerfile
@@ -37,5 +37,5 @@ ENV PATH=$INSTALL_DIR/osss-ucx/install/bin:/home/shmem/openmpi-4.1.6/install/bin
     OMPI_ALLOW_RUN_AS_ROOT=1 \
     OMPI_ALLOW_RUN_AS_ROOT_CONFIRM=1
 
-RUN python3 -m venv .venv
-RUN source /.venv/bin/activate && pip install setuptools cffi numpy
+RUN python3 -m venv /venv
+RUN source /venv/bin/activate && pip install setuptools cffi numpy

--- a/docker/osss_fedora/Dockerfile
+++ b/docker/osss_fedora/Dockerfile
@@ -36,5 +36,6 @@ ENV PATH=$INSTALL_DIR/osss-ucx/install/bin:/home/shmem/openmpi-4.1.6/install/bin
     OMPI_ALLOW_RUN_AS_ROOT=1 \
     OMPI_ALLOW_RUN_AS_ROOT_CONFIRM=1
 
-RUN ln -s /usr/bin/python3 /usr/bin/python
+RUN python3 -m venv .venv
+RUN ln -s /.venv/bin/python /usr/bin/python
 RUN python -m pip install setuptools cffi numpy

--- a/docker/osss_fedora/Dockerfile
+++ b/docker/osss_fedora/Dockerfile
@@ -1,4 +1,5 @@
 FROM fedora:latest
+SHELL ["/bin/bash", "-c"]
 
 ENV INSTALL_DIR=/home/shmem
 RUN mkdir /home/shmem

--- a/docker/osss_ubuntu/Dockerfile
+++ b/docker/osss_ubuntu/Dockerfile
@@ -44,5 +44,4 @@ ENV PATH=$INSTALL_DIR/osss-ucx/install/bin:/home/shmem/openmpi-4.1.6/install/bin
     OMPI_ALLOW_RUN_AS_ROOT_CONFIRM=1
 
 RUN python3 -m venv .venv
-RUN rm /usr/bin/python && ln -s /.venv/bin/python /usr/bin/python
-RUN python -m pip install setuptools cffi numpy
+RUN source /.venv/bin/activate && pip install setuptools cffi numpy

--- a/docker/osss_ubuntu/Dockerfile
+++ b/docker/osss_ubuntu/Dockerfile
@@ -44,5 +44,5 @@ ENV PATH=$INSTALL_DIR/osss-ucx/install/bin:/home/shmem/openmpi-4.1.6/install/bin
     OMPI_ALLOW_RUN_AS_ROOT=1 \
     OMPI_ALLOW_RUN_AS_ROOT_CONFIRM=1
 
-RUN python3 -m venv .venv
-RUN source /.venv/bin/activate && pip install setuptools cffi numpy
+RUN python3 -m venv /venv
+RUN source /venv/bin/activate && pip install setuptools cffi numpy

--- a/docker/osss_ubuntu/Dockerfile
+++ b/docker/osss_ubuntu/Dockerfile
@@ -1,4 +1,5 @@
 FROM ubuntu:latest
+SHELL ["/bin/bash", "-c"]
 
 ENV INSTALL_DIR=/home/shmem
 RUN mkdir /home/shmem

--- a/docker/osss_ubuntu/Dockerfile
+++ b/docker/osss_ubuntu/Dockerfile
@@ -13,7 +13,7 @@ RUN apt-get update -y && apt-get install -y \
   libtool                                   \
   pkg-config                                \
   libpmix-bin libpmix-dev                   \
-  python3 python3-pip python-is-python3
+  python3 python3-pip python-is-python3 python3-venv
 
 RUN cd $INSTALL_DIR                                                                                                             && \
     wget https://github.com/openucx/ucx/archive/refs/tags/v1.15.0.tar.gz                                                        && \
@@ -43,4 +43,6 @@ ENV PATH=$INSTALL_DIR/osss-ucx/install/bin:/home/shmem/openmpi-4.1.6/install/bin
     OMPI_ALLOW_RUN_AS_ROOT=1 \
     OMPI_ALLOW_RUN_AS_ROOT_CONFIRM=1
 
+RUN python3 -m venv .venv
+RUN rm /usr/bin/python && ln -s /.venv/bin/python /usr/bin/python
 RUN python -m pip install setuptools cffi numpy

--- a/docker/sos_fedora/Dockerfile
+++ b/docker/sos_fedora/Dockerfile
@@ -34,5 +34,4 @@ RUN cd $INSTALL_DIR                                                             
 
 ENV PATH="/home/shmem/SOS/install/bin:/usr/lib64/mpich/bin:${PATH}"
 RUN python3 -m venv .venv
-RUN ln -s /.venv/bin/python /usr/bin/python
-RUN python -m pip install numpy cffi setuptools
+RUN source /.venv/bin/activate && pip install numpy cffi setuptools

--- a/docker/sos_fedora/Dockerfile
+++ b/docker/sos_fedora/Dockerfile
@@ -1,6 +1,7 @@
 # adapted from https://github.com/Sandia-OpenSHMEM/SOS/blob/master/scripts/docker/Dockerfile
 
 FROM fedora:latest
+SHELL ["/bin/bash", "-c"]
 
 ENV INSTALL_DIR=/home/shmem
 RUN mkdir /home/shmem

--- a/docker/sos_fedora/Dockerfile
+++ b/docker/sos_fedora/Dockerfile
@@ -33,5 +33,6 @@ RUN cd $INSTALL_DIR                                                             
     make check TESTS= -j
 
 ENV PATH="/home/shmem/SOS/install/bin:/usr/lib64/mpich/bin:${PATH}"
-RUN ln -s /usr/bin/python3 /usr/bin/python
+RUN python3 -m venv .venv
+RUN ln -s /.venv/bin/python /usr/bin/python
 RUN python -m pip install numpy cffi setuptools

--- a/docker/sos_fedora/Dockerfile
+++ b/docker/sos_fedora/Dockerfile
@@ -34,5 +34,5 @@ RUN cd $INSTALL_DIR                                                             
     make check TESTS= -j
 
 ENV PATH="/home/shmem/SOS/install/bin:/usr/lib64/mpich/bin:${PATH}"
-RUN python3 -m venv .venv
-RUN source /.venv/bin/activate && pip install numpy cffi setuptools
+RUN python3 -m venv /venv
+RUN source /venv/bin/activate && pip install numpy cffi setuptools

--- a/docker/sos_ubuntu/Dockerfile
+++ b/docker/sos_ubuntu/Dockerfile
@@ -42,5 +42,4 @@ RUN cd $INSTALL_DIR                                                             
 
 ENV PATH="/home/shmem/SOS/install/bin:${PATH}"
 RUN python3 -m venv .venv
-RUN rm /usr/bin/python && ln -s /.venv/bin/python /usr/bin/python
-RUN python -m pip install numpy cffi setuptools
+RUN source /.venv/bin/activate && pip install numpy cffi setuptools

--- a/docker/sos_ubuntu/Dockerfile
+++ b/docker/sos_ubuntu/Dockerfile
@@ -42,5 +42,5 @@ RUN cd $INSTALL_DIR                                                             
     make check TESTS= -j
 
 ENV PATH="/home/shmem/SOS/install/bin:${PATH}"
-RUN python3 -m venv .venv
-RUN source /.venv/bin/activate && pip install numpy cffi setuptools
+RUN python3 -m venv /venv
+RUN source /venv/bin/activate && pip install numpy cffi setuptools

--- a/docker/sos_ubuntu/Dockerfile
+++ b/docker/sos_ubuntu/Dockerfile
@@ -1,6 +1,7 @@
 # adapted from https://github.com/Sandia-OpenSHMEM/SOS/blob/master/scripts/docker/Dockerfile
 
 FROM ubuntu:latest
+SHELL ["/bin/bash", "-c"]
 
 ENV INSTALL_DIR=/home/shmem
 RUN mkdir /home/shmem

--- a/docker/sos_ubuntu/Dockerfile
+++ b/docker/sos_ubuntu/Dockerfile
@@ -19,7 +19,7 @@ RUN apt-get update -y && apt-get install -y \
   libhwloc-dev                              \
   libevent-dev                              \
   mpich                                     \
-  python3 python3-pip python-is-python3
+  python3 python3-pip python-is-python3 python3-venv
 
 # Build Libfabric
 RUN cd $INSTALL_DIR                                                       && \
@@ -41,4 +41,6 @@ RUN cd $INSTALL_DIR                                                             
     make check TESTS= -j
 
 ENV PATH="/home/shmem/SOS/install/bin:${PATH}"
+RUN python3 -m venv .venv
+RUN rm /usr/bin/python && ln -s /.venv/bin/python /usr/bin/python
 RUN python -m pip install numpy cffi setuptools


### PR DESCRIPTION
An upstream change in Ubuntu containers caused an `externally-managed-environment` error. Using `venv` to get things working again.

```
#10 [6/6] RUN python -m pip install numpy cffi setuptools
#10 0.562 error: externally-managed-environment
#10 0.562 
#10 0.562 × This environment is externally managed
#10 0.562 ╰─> To install Python packages system-wide, try apt install
#10 0.562     python3-xyz, where xyz is the package you are trying to
#10 0.562     install.
#10 0.562     
#10 0.562     If you wish to install a non-Debian-packaged Python package,
#10 0.562     create a virtual environment using python3 -m venv path/to/venv.
#10 0.562     Then use path/to/venv/bin/python and path/to/venv/bin/pip. Make
#10 0.562     sure you have python3-full installed.
#10 0.562     
#10 0.562     If you wish to install a non-Debian packaged Python application,
#10 0.562     it may be easiest to use pipx install xyz, which will manage a
#10 0.562     virtual environment for you. Make sure you have pipx installed.
#10 0.562     
#10 0.562     See /usr/share/doc/python3.12/README.venv for more information.
#10 0.562 
#10 0.562 note: If you believe this is a mistake, please contact your Python installation or OS distribution provider. You can override this, at the risk of breaking your Python installation or OS, by passing --break-system-packages.
#10 0.562 hint: See PEP 668 for the detailed specification.
```