### PR TITLE
CI/CD: Add release workflow

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,10 @@
+version: 2
+updates:
+  - package-ecosystem: github-actions
+    directory: /
+    schedule:
+      interval: weekly
+  - package-ecosystem: pip
+    directory: /
+    schedule:
+      interval: weekly

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,120 @@
+name: dist
+
+on:  # yamllint disable-line rule:truthy
+  release:
+    types:
+      - published
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+
+  dist:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      id-token: write
+      attestations: write
+
+    steps:
+
+    - name: Checkout
+      uses: actions/checkout@v4
+
+    - name: Set SOURCE_DATE_EPOCH
+      run:  |
+        SOURCE_DATE_EPOCH=$(git log -1 --pretty=%ct)
+        echo SOURCE_DATE_EPOCH=$SOURCE_DATE_EPOCH >> $GITHUB_ENV
+        echo $(git log -1 --pretty=%ci) [timestamp=$SOURCE_DATE_EPOCH]
+
+    - name: Setup Python
+      uses: actions/setup-python@v5
+      with:
+        python-version: 3
+
+    - name: Upgrade pip
+      run:  python -m pip install -U pip
+
+    - name: Install build and twine
+      run:  python -m pip install -U build twine
+
+    - name: Build source distribution
+      run:  python -m build --sdist
+
+    - name: Check source distribution
+      run:  python -m twine check dist/*.tar.gz
+
+    - name: Compute SHA256 checksum
+      run:  sha256sum -b *.tar.gz >> sha256sum.txt
+      working-directory: dist
+
+    - name: Report SHA256 checksum
+      run:  |
+        echo '```'        >> $GITHUB_STEP_SUMMARY
+        cat sha256sum.txt >> $GITHUB_STEP_SUMMARY
+        echo '```'        >> $GITHUB_STEP_SUMMARY
+      working-directory: dist
+
+    - name: Upload distribution artifact
+      uses: actions/upload-artifact@v4
+      with:
+        name: dist
+        path: |
+          dist/*.tar.gz
+          dist/sha256sum.txt
+
+    - if: ${{ github.event_name == 'release' }}
+      name: Attest distribution artifact
+      uses: actions/attest-build-provenance@v1
+      with:
+        subject-path: dist/*.tar.gz
+
+  gh-publish:
+    if: ${{ github.event_name == 'release' }}
+    runs-on: ubuntu-latest
+    needs: dist
+    environment:
+      name: gh
+      url: https://github.com/mpi4py/shmem4py/releases
+    permissions:
+      contents: write
+
+    steps:
+
+    - name: Checkout
+      uses: actions/checkout@v4
+
+    - name: Download distribution artifact
+      uses: actions/download-artifact@v4
+      with:
+        name: dist
+        path: dist
+
+    - name: Publish package distributions to GitHub Releases
+      run:  gh release upload $TAG dist/*.tar.gz
+      env:
+        TAG: ${{ github.event.release.tag_name }}
+        GITHUB_TOKEN: ${{ github.token }}
+
+  pypi-publish:
+    if: ${{ github.event_name == 'release' }}
+    runs-on: ubuntu-latest
+    needs: dist
+    environment:
+      name: pypi
+      url: https://pypi.org/p/shmem4py/
+    permissions:
+      id-token: write
+
+    steps:
+
+    - name: Download distribution artifact
+      uses: actions/download-artifact@v4
+      with:
+        name: dist
+        path: dist
+
+    - name: Publish package distributions to PyPI
+      uses: pypa/gh-action-pypi-publish@release/v1


### PR DESCRIPTION
After this PR is merged, we can setup Trusted Publisher on PyPI https://docs.pypi.org/trusted-publishers/.