### PR TITLE
Fix latest Fedora and Ubuntu container builds

### DIFF
--- a/docker/oshmem_fedora/Dockerfile
+++ b/docker/oshmem_fedora/Dockerfile
@@ -16,10 +16,15 @@ RUN cd $INSTALL_DIR                                                             
     ./configure CFLAGS="-Wno-error -std=gnu17" --prefix=$INSTALL_DIR/ucx/ --disable-debug --disable-assertions --disable-params-check && \
     make -j $(nproc) && make install && cd .. && rm -rf ucx-1.19.0 v1.19.0.tar.gz
 
+# Patch Open MPI 4.1.7 for Fedora 44/GCC 16, which rejects its over-braced
+# scalar initializers in oshmem/mca/memheap/base/memheap_base_frame.c.
 RUN cd $INSTALL_DIR                                                                   && \
     wget -c https://download.open-mpi.org/release/open-mpi/v4.1/openmpi-4.1.7.tar.bz2 && \
     tar xf openmpi-4.1.7.tar.bz2                                                      && \
     cd openmpi-4.1.7                                                                  && \
+    sed -i -e 's/opal_list_t mca_memheap_base_components_opened = {{0}};/opal_list_t mca_memheap_base_components_opened = {0};/' \
+           -e 's/mca_memheap_map_t mca_memheap_base_map = {{{{0}}}};/mca_memheap_map_t mca_memheap_base_map = {0};/' \
+           oshmem/mca/memheap/base/memheap_base_frame.c                               && \
     ./configure --disable-dependency-tracking --disable-debug --disable-mem-debug --disable-mem-profile \
                 --disable-sphinx --disable-man-pages --disable-mpi-fortran --disable-dlopen             \
                 --with-ucx=$INSTALL_DIR/ucx/                                                            \

--- a/docker/osss_fedora/Dockerfile
+++ b/docker/osss_fedora/Dockerfile
@@ -16,10 +16,15 @@ RUN cd $INSTALL_DIR                                                             
     ./configure CFLAGS="-Wno-error -std=gnu17" --prefix=$INSTALL_DIR/ucx/ --disable-debug --disable-assertions --disable-params-check && \
     make -j $(nproc) && make install && cd .. && rm -rf ucx-1.19.0 v1.19.0.tar.gz
 
+# Patch Open MPI 4.1.7 for Fedora 44/GCC 16, which rejects its over-braced
+# scalar initializers in oshmem/mca/memheap/base/memheap_base_frame.c.
 RUN cd $INSTALL_DIR                                                                   && \
     wget -c https://download.open-mpi.org/release/open-mpi/v4.1/openmpi-4.1.7.tar.bz2 && \
     tar xf openmpi-4.1.7.tar.bz2                                                      && \
     cd openmpi-4.1.7                                                                  && \
+    sed -i -e 's/opal_list_t mca_memheap_base_components_opened = {{0}};/opal_list_t mca_memheap_base_components_opened = {0};/' \
+           -e 's/mca_memheap_map_t mca_memheap_base_map = {{{{0}}}};/mca_memheap_map_t mca_memheap_base_map = {0};/' \
+           oshmem/mca/memheap/base/memheap_base_frame.c                               && \
     ./configure --disable-dependency-tracking --disable-debug --disable-mem-debug --disable-mem-profile \
                 --disable-sphinx --disable-man-pages --disable-mpi-fortran --disable-dlopen             \
                 --with-ucx=$INSTALL_DIR/ucx/                                                            \

--- a/docker/osss_ubuntu/Dockerfile
+++ b/docker/osss_ubuntu/Dockerfile
@@ -34,11 +34,14 @@ RUN cd $INSTALL_DIR                                                             
                 --enable-oshmem --prefix=$INSTALL_DIR/openmpi                                        && \
     make -j $(nproc) install && cd .. && rm -rf openmpi-4.1.7 openmpi-4.1.7.tar.bz2
 
+# GCC 15 defaults to gnu23, where an empty parameter list means (void).
+# OSSS-UCX uses void (*)() for a table of collective callbacks with
+# different signatures, so build it as gnu17.
 RUN cd $INSTALL_DIR && \
     git clone https://github.com/openshmem-org/osss-ucx osss-ucx-src                                                                                     && \
     cd osss-ucx-src/                                                                                                                                     && \
     ./autogen.sh                                                                                                                                         && \
-    ./configure --prefix=$INSTALL_DIR/osss-ucx/ --enable-debug --enable-logging --with-pmix=/usr/lib/x86_64-linux-gnu/pmix2 --with-ucx=$INSTALL_DIR/ucx/ && \
+    ./configure CFLAGS="-std=gnu17" --prefix=$INSTALL_DIR/osss-ucx/ --enable-debug --enable-logging --with-pmix=/usr/lib/x86_64-linux-gnu/pmix2 --with-ucx=$INSTALL_DIR/ucx/ && \
     make -j $(nproc) && make install && cd .. && rm -rf osss-ucx-src
 
 ENV PATH=$INSTALL_DIR/osss-ucx/bin:$INSTALL_DIR/openmpi/bin:"${PATH}" \


### PR DESCRIPTION
## Summary

Fix container builds that started failing after `fedora:latest` and `ubuntu:latest` moved to newer distro/toolchain versions.

- Patch Open MPI 4.1.7 in Fedora containers before configure so GCC 16 accepts the OSHMEM memheap initializers.
- Build OSSS-UCX with `-std=gnu17` in the Ubuntu container so GCC 15 does not reinterpret legacy `void (*)()` callback table entries as `void (*)(void)`.

## Details

`fedora:latest` now resolves to Fedora 44, which ships GCC 16. Open MPI 4.1.7 fails with `--enable-oshmem` because GCC 16 rejects over-braced scalar initializers in `oshmem/mca/memheap/base/memheap_base_frame.c`. This patches the extracted Open MPI source to use portable `{0}` initializers.

`ubuntu:latest` now resolves to Ubuntu 26.04, whose default GCC 15 compiles C as `gnu23`. In C23, empty function parameter lists mean `(void)`, which breaks OSSS-UCX’s legacy `void (*)()` collective callback table. Building OSSS-UCX as `gnu17` preserves the semantics the upstream code expects.